### PR TITLE
Refactor construction and material classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tox.ini
 NERB.inp
 !dfjson.ipynb
 reffiles
+assets/sample_out/

--- a/dragonfly_doe2/doe/construction.py
+++ b/dragonfly_doe2/doe/construction.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+from enum import unique
+from typing import List
+
+from honeybee_energy.construction.opaque import OpaqueConstruction as OpConstr
+
+from .material import Material
+from . import blocks as fb
+
+
+@dataclass
+class Construction:
+    name: str
+    materials: List[Material]
+    absorptance: float
+    roughness: int
+
+    @classmethod
+    def from_hb_construction(cls, construction: OpConstr):
+        """Create inp construction from HB construction."""
+        roughdict = {'VeryRough': 1, 'Rough': 2, 'MediumRough': 3,
+                     'MediumSmooth': 4, 'Smooth': 5, 'VerySmooth': 6}
+        if not isinstance(construction, OpConstr):
+            # this should raise an error but for now I leave it to print until we
+            # support a handful number of types
+            print(
+                f'Unsupported type: {type(construction)}.\n'
+                'Currently only OpaqueConstruction type is supported.'
+            )
+            return cls(construction.display_name, [], 0, 0)
+
+        materials = [
+            Material.from_hb_material(material) for material in construction.materials
+        ]
+        absorptance = construction.materials[0].solar_absorptance
+        roughness = roughdict[construction.materials[0].roughness]
+
+        return cls(construction.display_name, materials, absorptance, roughness)
+
+    def to_inp(self, include_materials=True):
+
+        # temporary solution not return values for unsupported construction types
+        if not self.materials:
+            return ''
+
+        if include_materials:
+            block = ['\n'.join(material.to_inp() for material in self.materials)]
+        else:
+            block = []
+
+        materials = '\n      '.join(f'"{material.name}",' for material in self.materials)
+
+        layers_name = f'"{self.name} Layers"'
+        construction = f'{layers_name} = LAYERS\n' \
+            f'   MATERIAL                 = (\n      {materials[:-1]}\n   )\n' \
+            '   ..\n\n' \
+            f'"{self.name}" = CONSTRUCTION\n' \
+            '   TYPE                 = LAYERS\n' \
+            f'   ABSORPTANCE          = {self.absorptance}\n' \
+            f'   ROUGHNESS            = {self.roughness}\n' \
+            f'   LAYERS               = {layers_name}\n' \
+            '   ..\n'
+        block.append(construction)
+
+        return '\n\n'.join(block)
+
+    def __repr__(self) -> str:
+        return self.to_inp()
+
+@dataclass
+class ConstructionCollection:
+    """Construction object. Contains, materials and layers for *.inp file.
+
+        Returns:
+          $  Materials / Layers / Constructions *.inp block
+    """
+    constructions: List[Construction]
+
+    @classmethod
+    def from_hb_constructions(cls, constructions: List[OpConstr]):
+        unique_constructions = {
+            construction.display_name: construction for construction in constructions
+        }.values()
+
+        constructions = [
+            Construction.from_hb_construction(construction)
+            for construction in unique_constructions
+        ]
+        return cls(constructions)
+
+    def to_inp(self):
+
+        block = [fb.matslayers]
+
+        # collect all the materials and ensure to only include the unique ones
+        materials = set(
+            mat.to_inp()
+            for construction in self.constructions
+            for mat in construction.materials
+        )
+        block.append('\n\n'.join(materials))
+
+        # add constructions - layers are created as part of each construction definition
+        for construction in self.constructions:
+            block.append(construction.to_inp(include_materials=False))
+
+        return '\n'.join(block)
+
+    def __repr__(self):
+        return self.to_inp()

--- a/dragonfly_doe2/doe/material.py
+++ b/dragonfly_doe2/doe/material.py
@@ -2,11 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Union
 
-from honeybee_energy.construction.opaque import OpaqueConstruction as OpConstr
 from honeybee_energy.material.opaque import EnergyMaterial, EnergyMaterialNoMass
 from ladybug.datatype import UNITS as lbt_units, TYPESDICT as lbt_td
-
-from . import blocks as fb
 
 
 class MaterialType(Enum):
@@ -25,7 +22,7 @@ def _unit_convertor(value, to_, from_):
         raise ValueError(f'Invalid type: {from_}')
 
     value = base_type.to_unit(value, to_, from_)
-    return value
+    return value[0]
 
 
 @dataclass
@@ -41,7 +38,7 @@ class NoMassMaterial:
 
     def to_inp(self):
         return f'"{self.name}" = MATERIAL\n' \
-            f'   TYPE           = {MaterialType.no_mass}\n' \
+            f'   TYPE           = {MaterialType.no_mass.value}\n' \
             f'   RESISTANCE     = {self.resistance}\n' \
             '   ..'
 
@@ -60,7 +57,7 @@ class MassMaterial:
         name = material.display_name
         thickness = _unit_convertor([material.thickness], 'ft', 'm')
         conductivity = _unit_convertor([material.conductivity], 'Btu/h-ft2', 'W/m2')
-        density = _unit_convertor(material.density/16.018)
+        density = material.density / 16.018
         specific_heat = _unit_convertor([material.specific_heat], 'Btu/lb', 'J/kg')
         return cls(
                 name, thickness, conductivity, density, specific_heat
@@ -68,7 +65,7 @@ class MassMaterial:
 
     def to_inp(self):
         return f'"{self.name}" = MATERIAL\n' \
-            f'   TYPE            = {MaterialType.mass}\n' \
+            f'   TYPE            = {MaterialType.mass.value}\n' \
             f'   THICKNESS       = {self.thickness}\n' \
             f'   CONDUCTIVITY    = {self.conductivity}\n' \
             f'   DENSITY         = {self.density}\n' \
@@ -96,70 +93,6 @@ class Material:
 
     def to_inp(self) -> str:
         return self.material.to_inp()
-
-    def __repr__(self):
-        return self.to_inp()
-
-
-@dataclass
-class MatsLayersConstructions(object):
-    """Construction object. Contains, materials and layers for *.inp file.
-    Intent: Pass list of constrs in dfm to this class.
-    Should return enum of mats, 'layers' (stupid f'n eQuest obj imo..), Constr objs
-    via __repr__.
-
-        Returns:
-          $  Materials / Layers / Constructions *.inp block
-    """
-    inp_constructions: list = None
-    inp_layers: list = None
-    inp_materials: list = None
-
-    @classmethod
-    def from_hb_constructions(cls, hb_constructions: list):
-        """Create input data for eQuest $ Materials / Layers / Constructions *.inp block"""
-        roughdict = {'VeryRough': 1, 'Rough': 2, 'MediumRough': 3,
-                     'MediumSmooth': 4, 'Smooth': 5, 'VerySmooth': 6}
-        cls_ = cls()
-        inp_cons = []
-        inp_layrs = []
-        inp_mats = []
-        for i, constr in enumerate(hb_constructions):
-            if type(constr) == OpConstr:
-                mats = [mat for mat in constr.materials]
-
-                for mat in mats:
-                    inp_mats.append(Material(mat))
-
-                matstr = ''.join(f'"{m.display_name}", ' for m in mats)
-                inp_layrs.append(
-                    f'"{constr.display_name}_{i} Layers" = LAYERS\n'
-                    f'   MATERIAL                 = ( {matstr} )\n   ..\n')
-
-                inp_cons.append(
-                    f'"{constr.display_name}_{i}" = CONSTRUCTION\n'
-                    f'   TYPE                 = LAYERS\n'
-                    f'   ABSORPTANCE          = {constr.materials[0].solar_absorptance}\n'
-                    f'   ROUGHNESS            = {roughdict[constr.materials[0].roughness]}\n'
-                    f'   LAYERS               = "{constr.display_name}_{i} Layers"\n   ..\n')
-
-        cls_.inp_constructions = inp_cons
-        cls_.inp_layers = inp_layrs
-        cls_.inp_materials = inp_mats
-        return(cls_)
-
-    def to_inp(self):
-        # ? if these could be list comps that would be chill,
-        # TODO: Look at replacing with lambda func
-
-        block = fb.matslayers
-        for mat in self.inp_materials:
-            block += mat.to_inp()
-        for lay in self.inp_layers:
-            block += lay
-        for cons in self.inp_constructions:
-            block += cons
-        return(block)
 
     def __repr__(self):
         return self.to_inp()


### PR DESCRIPTION
@TfedUD, see my comments for each commit.

### Materials
1. cleaned up the code and to_inp methods
2. created two different classes for the two different types of materials
3. used dataclass to keep it consistent

### Construction
1. separated material module from construction
2. renamed the strange name to construction
3. removed comments from docstrings 
4. moved layers inside the construction class - users don't need to interact with those values

If you want to merge this in, please make sure you use rebase and merge to avoid creating an empty commit.
